### PR TITLE
Add client project reference to server

### DIFF
--- a/src/Jordan2.Client/Jordan2.Client.csproj
+++ b/src/Jordan2.Client/Jordan2.Client.csproj
@@ -4,4 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Jordan2.Server/Jordan2.Server.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add a project reference from Jordan2.Client to Jordan2.Server so the client can use server models

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e0370fa3e0832385cc78d0f4cefb9b